### PR TITLE
chore: ignore .npmrc for Vercel compatibility and remove from GitHub …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .pnp.js
 .yarn/install-state.gz
 
+# Ignoring .npmrc to prevent conflicts with Vercel's node version management
+.npmrc
+
 # testing
 /coverage
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Version of Node to use
-use-node-version=20.10.0


### PR DESCRIPTION
…repo

This commit updates the .gitignore to exclude the .npmrc file, ensuring
local node version settings do not interfere with Vercel's build process.
Additionally, it removes the previously tracked .npmrc file from the
repository to prevent any deployment issues related to unsupported
use-node-version configurations.

commit-id:4fda4aca